### PR TITLE
Avoid sending multiple order confirmations

### DIFF
--- a/Controller/Payment/Index.php
+++ b/Controller/Payment/Index.php
@@ -210,18 +210,18 @@ class Index extends \Magento\Framework\App\Action\Action
             if ($order) {
                 $result['order_ref'] = $order->getIncrementId();
 
-                // Add notice in the logs about the event
                 if (isset($orderIsAlreadyCreated) && $orderIsAlreadyCreated) {
                     $this->logger->debug('Order was already created for quote ID ' . $quoteId);
                 } else {
                     $this->logger->debug('Order created for quote ID ' . $quoteId);
-                }
 
-                if ($order->getCanSendNewEmailFlag()) {
-                    try {
-                        $this->orderSender->send($order);
-                    } catch (\Exception $e) {
-                        $this->_logger->critical($e);
+                    if ($order->getCanSendNewEmailFlag()) {
+                        try {
+                            $this->orderSender->send($order);
+                            $order->setCanSendNewEmailFlag(false)->save();
+                        } catch (\Exception $e) {
+                            $this->_logger->critical($e);
+                        }
                     }
                 }
             } else {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mondido/magento2-mondido",
     "description": "Mondido payment module for Magento 2.",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "type": "magento2-module",
     "repositories": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mondido_Mondido" setup_version="1.1.4">
+    <module name="Mondido_Mondido" setup_version="1.1.5">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
Only send order confirmation if `$orderIsAlreadyCreated` is not set and `$order->getCanSendNewEmailFlag()` returns `true`. Also make sure the flag is set by running `$order->setCanSendNewEmailFlag(false)->save()` after the order confirmation has been sent.