### PR TITLE
Version 1.3.5

### DIFF
--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -167,6 +167,20 @@ class Customer extends Mondido
     }
 
     /**
+     * Show customer
+     *
+     * @param int $id Customer ID
+     *
+     * @return string
+     */
+    public function show($id)
+    {
+        $method = 'GET';
+
+        return $this->call($method, $this->resource, (string) $id);
+    }
+
+    /**
      * Fetch Mondido ID using "ref" field (Magento customer ID)
      *
      * @param integer $referenceId Magento customer ID

--- a/Model/Api/Transaction.php
+++ b/Model/Api/Transaction.php
@@ -281,11 +281,11 @@ class Transaction extends Mondido
 
                 return $this->call($method, $this->resource, [$id, 'capture'], $data);
             } else {
-                return $currentTransactionJson;
+                return false;
             }
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/Model/HostedWindow.php
+++ b/Model/HostedWindow.php
@@ -128,7 +128,7 @@ class HostedWindow extends \Magento\Payment\Model\Method\AbstractMethod
         $result = $this->transaction->capture($order, $amount);
         $result = json_decode($result);
 
-        if (is_object($result) && property_exists($result, 'code') && $result->code != 200) {
+        if (is_object($result) && property_exists($result, 'code')) {
             $message = sprintf(
                 __("Mondido returned error code %d: %s (%s)"),
                 $result->code,
@@ -136,6 +136,10 @@ class HostedWindow extends \Magento\Payment\Model\Method\AbstractMethod
                 $result->name
             );
             throw new \Magento\Framework\Exception\LocalizedException(__($message));
+        }
+
+        if (!is_object($result) || (is_object($result) && !property_exists($result, 'id'))) {
+            throw new \Magento\Framework\Exception\LocalizedException(__('Could not capture order online'));
         }
 
         $payment->setTransactionId($result->id)->setIsTransactionClosed(false);

--- a/Observer/CustomerSaveObserver.php
+++ b/Observer/CustomerSaveObserver.php
@@ -45,7 +45,7 @@ class CustomerSaveObserver implements \Magento\Framework\Event\ObserverInterface
         $customerObject = $observer->getCustomerDataObject();
 
         // Update or create the data
-        $customerApi->handle($customerObject);
+        // $customerApi->handle($customerObject);
 
         return $observer;
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mondido/magento2-mondido",
     "description": "Mondido payment module for Magento 2.",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "type": "magento2-module",
     "repositories": [
         {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mondido_Mondido" setup_version="1.3.4">
+    <module name="Mondido_Mondido" setup_version="1.3.5">
         <sequence>
             <module name="Magento_Checkout"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
- Add method to get/show customer via the Mondido API
- Don't collect totals on payment webhook
- Add customer data to order on payment webhook
- Temporarily remove API call in customer save observer (causing a bug with next show transaction call to Mondido)
- Adjust capture methods: return `false` if Mondido API wasn't contacted, throw an exception if capture result isn't an object containing a property named `id` and faulty check for `code` in the capture response